### PR TITLE
[IN PROG] Fix mem leaks

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,8 +18,7 @@
         "cacheVariables": {
           "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
           "CMAKE_BUILD_TYPE": "Debug",
-          "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
-          "CMAKE_C_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+          "CMAKE_CXX_FLAGS": "-ggdb -fsanitize=address -fno-omit-frame-pointer -fno-inline -fno-inline-functions -fno-default-inline",
           "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address",
           "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address"
         }

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ run: build
 ### Testing
 
 .PHONY: unit-test
-unit-test: build
-	./build/tree-walk/tests/tree-walk-tst
+unit-test: build-asan
+	./build-asan/tree-walk/tests/tree-walk-tst
 
 .PHONY: system-test
-system-test: build
+system-test: build-asan
 	pytest
 
 .PHONY: test

--- a/tree-walk/src/CMakeLists.txt
+++ b/tree-walk/src/CMakeLists.txt
@@ -14,9 +14,6 @@ add_library(
   stmt_printer.cpp
   value_printer.cpp)
 target_include_directories(tree-walk-lib PUBLIC .)
-target_compile_options(tree-walk-lib PRIVATE -ggdb)
-target_compile_options(tree-walk-lib PRIVATE -fno-inline -fno-inline-functions
-                                             -fno-default-inline)
 
 add_executable(tree-walk main.cpp)
 target_link_libraries(tree-walk PRIVATE tree-walk-lib CLI11::CLI11)

--- a/tree-walk/src/environment.cpp
+++ b/tree-walk/src/environment.cpp
@@ -1,6 +1,7 @@
 #include <environment.h>
 
 #include <errs.h>
+#include <func.h>
 
 namespace plox {
 namespace treewalk {
@@ -23,18 +24,18 @@ Environment::extend(std::shared_ptr<Environment> scope) {
 Environment::Environment(std::shared_ptr<Environment> parent)
     : d_parent(parent), d_isScopeStart(true), d_isScopeEnd(true) {}
 
-void Environment::assign(const std::string &name, const Value &v) {
+void Environment::assign(const std::string &name, Value &&v) {
   // Assignment dictates the var must already exist
   if (d_map.contains(name)) {
-    d_map[name] = v;
+    d_map[name] = std::move(v);
   } else if (d_parent) {
-    d_parent->assign(name, v);
+    d_parent->assign(name, std::move(v));
   } else {
     throw InterpretException("Cannot assign unknown variable: " + name);
   }
 }
 
-void Environment::define(const std::string &name, const Value &v) {
+void Environment::define(const std::string &name, Value &&v) {
   if (!d_isScopeEnd) {
     throw InterpretException(
         "Internal Lox error: Tried to define a variable '" + name +
@@ -47,18 +48,18 @@ void Environment::define(const std::string &name, const Value &v) {
     throw InterpretException("Cannot redefine variable: " + name);
   }
 
-  d_map[name] = v;
+  d_map[name] = std::move(v);
 }
 
-void Environment::upsertInScope(const std::string &name, const Value &v) {
+void Environment::upsertInScope(const std::string &name, Value &&v) {
   if (isVarInScope(name)) {
-    return assign(name, v);
+    return assign(name, std::move(v));
   }
 
-  return define(name, v);
+  return define(name, std::move(v));
 }
 
-Value Environment::get(const std::string &name) const {
+Value &Environment::get(const std::string &name) {
   if (d_map.contains(name)) {
     return d_map.at(name);
   } else if (d_parent) {
@@ -98,6 +99,15 @@ ScopedSwap::ScopedSwap(std::shared_ptr<Environment> &a,
   std::swap(d_a, d_b);
 }
 ScopedSwap::~ScopedSwap() { std::swap(d_a, d_b); }
+
+// void invertOwnership(const std::string& fnName, FnDescShrdPtr fn) {
+//   std::shared_ptr<Environment> envShared = fn->getClosure();
+
+//   fn->setClosure(envShared);
+//   auto a = FnDescWkPtr(fn);
+//   envShared->assign(fnName, {FnDescWkPtr(fn)});
+// }
+
 } // namespace environmentutils
 
 } // namespace treewalk

--- a/tree-walk/src/environment.h
+++ b/tree-walk/src/environment.h
@@ -31,11 +31,11 @@ public:
   extend(std::shared_ptr<Environment> scope);
 
   // Operations
-  void assign(const std::string &name, const Value &v);
-  void define(const std::string &name, const Value &v = {});
-  void upsertInScope(const std::string &name, const Value &v);
+  void assign(const std::string &name, Value &&v);
+  void define(const std::string &name, Value &&v = {});
+  void upsertInScope(const std::string &name, Value &&v);
 
-  Value get(const std::string &name) const;
+  Value &get(const std::string &name);
 
   bool isVarInScope(const std::string &name) const;
 
@@ -64,6 +64,14 @@ private:
   std::shared_ptr<Environment> &d_a;
   std::shared_ptr<Environment> &d_b;
 };
+
+// Utility to invert ownership from an environment to a function. Ordinarily
+// an environment will own a function and the function dies when the environment
+// goes out of scope. However, if a function is returned to a parent scope the
+// environment that the function depends on must live as long as the function
+// lives.
+// void invertOwnership(FnDescShrdPtr fn);
+
 } // namespace environmentutils
 
 } // namespace treewalk

--- a/tree-walk/src/func.cpp
+++ b/tree-walk/src/func.cpp
@@ -32,17 +32,25 @@ Value Function::execute(std::shared_ptr<Environment> env,
 }
 
 FunctionDescription::FunctionDescription(std::string_view name,
-                                         std::shared_ptr<Environment> closure,
+                                         std::weak_ptr<Environment> closure,
                                          std::shared_ptr<const Function> fn)
-    : d_name(name), d_closure(closure), d_fn(fn), d_isInitialiser(false) {}
+    : d_name(name),
+      d_closure(std::make_shared<OwnershipHelper<Environment>>(closure)),
+      d_fn(fn), d_isInitialiser(false) {}
 
 std::string_view FunctionDescription::getName() const { return d_name; }
 
 void FunctionDescription::setName(std::string_view name) { d_name = name; }
 
-std::shared_ptr<Environment> &FunctionDescription::getClosure() {
-  return d_closure;
+std::shared_ptr<Environment> FunctionDescription::getClosure() {
+  return d_closure->getStrong();
 }
+
+void FunctionDescription::setClosure(std::weak_ptr<Environment> closure) {
+  d_closure->hold(closure);
+}
+
+void FunctionDescription::ownClosure() { d_closure->becomeOwner(); }
 
 const std::shared_ptr<const Function> &
 FunctionDescription::getFunction() const {

--- a/tree-walk/src/func.cpp
+++ b/tree-walk/src/func.cpp
@@ -34,7 +34,7 @@ Value Function::execute(std::shared_ptr<Environment> env,
 FunctionDescription::FunctionDescription(std::string_view name,
                                          std::shared_ptr<Environment> closure,
                                          std::shared_ptr<const Function> fn)
-    : d_name(name), d_closure(closure), d_fn(fn) {}
+    : d_name(name), d_closure(closure), d_fn(fn), d_isInitialiser(false) {}
 
 std::string_view FunctionDescription::getName() const { return d_name; }
 

--- a/tree-walk/src/func.h
+++ b/tree-walk/src/func.h
@@ -4,6 +4,7 @@
 #include <environment.h>
 #include <func_native.h>
 #include <interpreter.h>
+#include <ownershiphelper.h>
 #include <stmt.h>
 #include <value.h>
 
@@ -32,20 +33,38 @@ private:
 
 class FunctionDescription {
 public:
-  FunctionDescription(std::string_view name,
-                      std::shared_ptr<Environment> closure,
+  FunctionDescription(std::string_view name, std::weak_ptr<Environment> closure,
                       std::shared_ptr<const Function> fn);
 
   std::string_view getName() const;
   void setName(std::string_view name);
-  std::shared_ptr<Environment> &getClosure();
+  std::shared_ptr<Environment> getClosure();
+  void setClosure(std::weak_ptr<Environment> closure);
   const std::shared_ptr<const Function> &getFunction() const;
   bool isInitialiser() const;
   void setIsInitialiser(bool b);
+  void ownClosure();
 
 private:
   std::string_view d_name;
-  std::shared_ptr<Environment> d_closure;
+  // d_closure will ordinarily be a weak_ptr to avoid memory leaks through
+  // circular references. Note in the ordinary case the scope owns the function
+  // through a strong ptr.
+  //
+  // parentEnv <-strong- fnEnv <-weak- Fn
+  //     |                              ^
+  //     |                              |
+  //     +------------strong------------+
+  //
+  // When a function is returned from a scope, it must now own the environment
+  // to keep it alive. In this case d_closure will be a shared_ptr.
+  //
+  // parentEnv <-strong- fnEnv <-strong- Fn
+  //     |                                ^
+  //     |                                |
+  //     +------------weak----------------+
+  //
+  std::shared_ptr<OwnershipHelper<Environment>> d_closure;
   std::shared_ptr<const Function> d_fn;
   bool d_isInitialiser;
 };

--- a/tree-walk/src/func_native.cpp
+++ b/tree-walk/src/func_native.cpp
@@ -23,7 +23,8 @@ void addClock(std::shared_ptr<Environment> env) {
   auto clockFn = std::make_shared<FunctionDescription>(
       s_name, env,
       std::make_shared<Function>(std::vector<std::string_view>{}, clock));
-  env->define(s_name, clockFn);
+  env->define(s_name,
+              std::make_shared<OwnershipHelper<FunctionDescription>>(clockFn));
 }
 
 void addVersion(std::shared_ptr<Environment> env) {
@@ -35,7 +36,8 @@ void addVersion(std::shared_ptr<Environment> env) {
   auto versionFn = std::make_shared<FunctionDescription>(
       s_name, env,
       std::make_shared<Function>(std::vector<std::string_view>{}, version));
-  env->define(s_name, versionFn);
+  env->define(s_name, std::make_shared<OwnershipHelper<FunctionDescription>>(
+                          versionFn));
 }
 
 } // namespace nativefunc

--- a/tree-walk/src/interpreter.cpp
+++ b/tree-walk/src/interpreter.cpp
@@ -343,7 +343,7 @@ Value InterpreterVisitor::invoke(const ClsDefShrdPtr &clsDefSPtr,
           *std::get<FnDescOwnrHlpr>(v)->getStrong());
       // Bind the current environment to the function so the member function can
       // be stored in a variable outside the class.
-      fnDescCpy->getClosure() = currEnv;
+      fnDescCpy->setClosure(currEnv);
       currEnv->assign(
           k, std::make_shared<OwnershipHelper<FunctionDescription>>(fnDescCpy));
     }

--- a/tree-walk/src/interpreter.cpp
+++ b/tree-walk/src/interpreter.cpp
@@ -33,6 +33,7 @@ static ValuePrinter s_valuePrinter;
 struct AdditionVisitor {
   Value operator()(double l, double r);
   Value operator()(std::string &l, std::string &r);
+  Value operator()(std::string &l, double r);
   Value operator()(auto &&l, auto &&r);
 } s_adder;
 
@@ -458,6 +459,10 @@ Value AdditionVisitor::operator()(double l, double r) { return l + r; }
 
 Value AdditionVisitor::operator()(std::string &l, std::string &r) {
   return l + r;
+}
+
+Value AdditionVisitor::operator()(std::string &l, double r) {
+  return l + std::to_string(r);
 }
 
 Value AdditionVisitor::operator()(auto &&l, auto &&r) {

--- a/tree-walk/src/interpreter.cpp
+++ b/tree-walk/src/interpreter.cpp
@@ -340,12 +340,12 @@ Value InterpreterVisitor::invoke(const ClsDefShrdPtr &clsDefSPtr,
         std::shared_ptr<Environment>(new Environment(*currDef->getClosure()));
     for (const auto &[k, v] : *currEnv) {
       auto fnDescCpy = std::make_shared<FunctionDescription>(
-        *std::get<FnDescOwnrHlpr>(v)->getStrong());
+          *std::get<FnDescOwnrHlpr>(v)->getStrong());
       // Bind the current environment to the function so the member function can
       // be stored in a variable outside the class.
       fnDescCpy->getClosure() = currEnv;
       currEnv->assign(
-        k, std::make_shared<OwnershipHelper<FunctionDescription>>(fnDescCpy));
+          k, std::make_shared<OwnershipHelper<FunctionDescription>>(fnDescCpy));
     }
 
     // Create ClassInstance for the current class in the heirarchy.
@@ -367,7 +367,8 @@ Value InterpreterVisitor::invoke(const ClsDefShrdPtr &clsDefSPtr,
   } while (currDef);
 
   if (leafClass->getClosure()->isVarInScope("init")) {
-    invoke(std::get<FnDescOwnrHlpr>(leafClass->getClosure()->get("init")), call);
+    invoke(std::get<FnDescOwnrHlpr>(leafClass->getClosure()->get("init")),
+           call);
   }
 
   return leafClass;

--- a/tree-walk/src/interpreter.cpp
+++ b/tree-walk/src/interpreter.cpp
@@ -63,6 +63,16 @@ struct ReturnEx : public std::runtime_error {
   ReturnEx(Value v) : d_val(v), std::runtime_error("return"){};
   Value d_val;
 };
+
+template <typename T>
+std::shared_ptr<T> upgradeWeakToShared(std::weak_ptr<T> weak) {
+  auto shrd = weak.lock();
+  if (shrd) {
+    return shrd;
+  }
+  throw InterpretException(
+      "Internal lox error upgrading weak ptr to shared ptr!");
+}
 } // namespace
 
 InterpreterVisitor::InterpreterVisitor(std::shared_ptr<Environment> &env)
@@ -142,7 +152,8 @@ void InterpreterVisitor::operator()(Fun &funStmt) {
       funStmt.name, d_env,
       std::make_shared<Function>(std::move(funStmt.params),
                                  std::move(funStmt.stmts)));
-  d_env->define(std::string(funStmt.name), f);
+  d_env->define(std::string(funStmt.name),
+                std::make_shared<OwnershipHelper<FunctionDescription>>(f));
 
   if (!funStmt.isMethod) {
     // Extend scope so this function can have an Environment with only the
@@ -191,7 +202,7 @@ void InterpreterVisitor::operator()(const VarDecl &varDecl) {
   if (varDecl.expr) {
     val = std::visit(*this, *varDecl.expr);
   }
-  d_env->define(name, val);
+  d_env->define(name, std::move(val));
 }
 
 void InterpreterVisitor::operator()(const While &whileStmt) {
@@ -203,8 +214,8 @@ void InterpreterVisitor::operator()(const While &whileStmt) {
 Value InterpreterVisitor::operator()(const Assign &assign) {
   auto name = std::string(assign.name);
   Value val = std::visit(*this, *assign.value);
-  d_env->assign(name, val);
-  return val;
+  d_env->assign(name, std::move(val));
+  return {};
 }
 
 Value InterpreterVisitor::operator()(const Binary &bnry) {
@@ -238,8 +249,9 @@ Value InterpreterVisitor::operator()(const Binary &bnry) {
   }
 }
 
-Value InterpreterVisitor::invoke(const FnDescShrdPtr &fnDescSPtr,
+Value InterpreterVisitor::invoke(const FnDescOwnrHlpr &fnDescOwnrHlpr,
                                  const Call &call) {
+  auto fnDescSPtr = fnDescOwnrHlpr->getStrong();
   if (!fnDescSPtr) {
     throw InterpretException(
         "Internal error! Function closure pointer is null!");
@@ -266,7 +278,7 @@ Value InterpreterVisitor::invoke(const FnDescShrdPtr &fnDescSPtr,
   const std::vector<std::string_view> &fArgNames = fnSPtr->getArgNames();
   for (int i = 0; i < call.args.size(); i++) {
     Value v = std::visit(*this, *call.args[i]);
-    fEnv->define(std::string(fArgNames[i]), v);
+    fEnv->define(std::string(fArgNames[i]), std::move(v));
   }
 
   // Update environment to be the environment of the function, and swap back on
@@ -291,6 +303,21 @@ Value InterpreterVisitor::invoke(const FnDescShrdPtr &fnDescSPtr,
     // will throw and be caught below
     return fnSPtr->execute(d_env, *this);
   } catch (ReturnEx &ex) {
+    // If we return a function from the closure we need to invert the ownership
+    // since now the environment must live as long as the function rather than
+    // the function living as long as the environment
+    if (std::holds_alternative<FnDescOwnrHlpr>(ex.d_val)) {
+      auto ownerHelper = std::get<FnDescOwnrHlpr>(ex.d_val);
+      auto fn = ownerHelper->getStrong();
+      // Tell function to own the closure
+      fn->ownClosure();
+      // Tell Environment to become a borrower
+      Value &fnInEnv = fn->getClosure()->get(std::string(fn->getName()));
+      std::get<FnDescOwnrHlpr>(fnInEnv)->becomeBorrower();
+
+      // Return copy of Owner around function with a strong ref to keep it alive
+      ex.d_val = std::make_shared<OwnershipHelper<FunctionDescription>>(fn);
+    }
     return ex.d_val;
   }
 }
@@ -312,12 +339,13 @@ Value InterpreterVisitor::invoke(const ClsDefShrdPtr &clsDefSPtr,
     auto currEnv =
         std::shared_ptr<Environment>(new Environment(*currDef->getClosure()));
     for (const auto &[k, v] : *currEnv) {
-      auto fnDefCopy =
-          std::make_shared<FunctionDescription>(*std::get<FnDescShrdPtr>(v));
+      auto fnDescCpy = std::make_shared<FunctionDescription>(
+        *std::get<FnDescOwnrHlpr>(v)->getStrong());
       // Bind the current environment to the function so the member function can
       // be stored in a variable outside the class.
-      fnDefCopy->getClosure() = currEnv;
-      currEnv->assign(k, fnDefCopy);
+      fnDescCpy->getClosure() = currEnv;
+      currEnv->assign(
+        k, std::make_shared<OwnershipHelper<FunctionDescription>>(fnDescCpy));
     }
 
     // Create ClassInstance for the current class in the heirarchy.
@@ -339,7 +367,7 @@ Value InterpreterVisitor::invoke(const ClsDefShrdPtr &clsDefSPtr,
   } while (currDef);
 
   if (leafClass->getClosure()->isVarInScope("init")) {
-    invoke(std::get<FnDescShrdPtr>(leafClass->getClosure()->get("init")), call);
+    invoke(std::get<FnDescOwnrHlpr>(leafClass->getClosure()->get("init")), call);
   }
 
   return leafClass;
@@ -350,8 +378,8 @@ Value InterpreterVisitor::operator()(const Call &call) {
   // in chains we may need to evaluate a preceeding function i.e. fn(1)(2);
   Value callee = std::visit(*this, *call.callee);
 
-  if (std::holds_alternative<FnDescShrdPtr>(callee)) {
-    return invoke(std::get<FnDescShrdPtr>(callee), call);
+  if (std::holds_alternative<FnDescOwnrHlpr>(callee)) {
+    return invoke(std::get<FnDescOwnrHlpr>(callee), call);
   } else if (std::holds_alternative<ClsDefShrdPtr>(callee)) {
     return invoke(std::get<ClsDefShrdPtr>(callee), call);
   } else {
@@ -423,15 +451,15 @@ Value InterpreterVisitor::operator()(const Set &set) {
   }
 
   Value val = std::visit(*this, *set.value);
-  if (std::holds_alternative<FnDescShrdPtr>(val)) {
-    FnDescShrdPtr fnCopy =
-        std::make_shared<FunctionDescription>(*std::get<FnDescShrdPtr>(val));
+  if (std::holds_alternative<FnDescOwnrHlpr>(val)) {
+    auto fnCopy = std::make_shared<FunctionDescription>(
+        *std::get<FnDescOwnrHlpr>(val)->getStrong());
     fnCopy->setName(set.property);
     fnCopy->setIsInitialiser(set.property == "init");
-    val = fnCopy;
+    val = std::make_shared<OwnershipHelper<FunctionDescription>>(fnCopy);
   }
   std::get<ClsInstShrdPtr>(obj)->getClosure()->upsertInScope(
-      std::string(set.property), val);
+      std::string(set.property), std::move(val));
   return {};
 }
 

--- a/tree-walk/src/interpreter.cpp
+++ b/tree-walk/src/interpreter.cpp
@@ -275,7 +275,6 @@ Value InterpreterVisitor::invoke(const FnDescShrdPtr &fnDescSPtr,
 
   // Special behaviour for initialisers - always return "this"
   if (fnDescSPtr->isInitialiser()) {
-    Value _this = fnDescSPtr->getClosure()->get("this");
     try {
       fnSPtr->execute(d_env, *this);
     } catch (ReturnEx &ex) {
@@ -284,7 +283,7 @@ Value InterpreterVisitor::invoke(const FnDescShrdPtr &fnDescSPtr,
             "No explicit return allowed from a class initialiser");
       }
     }
-    return _this;
+    return fnDescSPtr->getClosure()->get("this");
   }
 
   try {

--- a/tree-walk/src/interpreter.h
+++ b/tree-walk/src/interpreter.h
@@ -42,7 +42,7 @@ struct InterpreterVisitor {
   Value operator()(const ast::Variable &var);
 
 private:
-  Value invoke(const FnDescShrdPtr &fnSPtr, const ast::Call &call);
+  Value invoke(const FnDescOwnrHlpr &fnSPtr, const ast::Call &call);
   Value invoke(const ClsDefShrdPtr &factSPtr, const ast::Call &call);
   std::shared_ptr<Environment> d_env;
 };

--- a/tree-walk/src/main.cpp
+++ b/tree-walk/src/main.cpp
@@ -22,6 +22,10 @@ void initNativeFuncs(std::shared_ptr<Environment> env) {
   nativefunc::addVersion(env);
 }
 
+void initKeywords(std::shared_ptr<Environment> env) {
+  env->define("nil", std::monostate{});
+}
+
 int run(const std::string &buff) {
   // Scan
   std::vector<SyntaxException> syntErrs;
@@ -125,6 +129,7 @@ int main(int argc, char **argv) {
   // Route to desired behaviour
   using namespace plox::treewalk;
   initNativeFuncs(s_globals);
+  initKeywords(s_globals);
   int rc = 0;
   if (script) {
     rc = runFile(script.value());

--- a/tree-walk/src/ownershiphelper.h
+++ b/tree-walk/src/ownershiphelper.h
@@ -1,0 +1,137 @@
+#ifndef TREEWALK_OWNERSHIP_HELPER_H
+#define TREEWALK_OWNERSHIP_HELPER_H
+
+#include <memory>
+#include <string>
+#include <variant>
+
+namespace plox {
+namespace treewalk {
+
+// A class responsible for switching between shared and weak pointers depending
+// on who owns the component.
+
+template <typename T> class OwnershipHelper {
+public:
+  // Constructors
+  OwnershipHelper(std::shared_ptr<T> strong);
+  OwnershipHelper(std::weak_ptr<T> weak);
+
+  OwnershipHelper(const OwnershipHelper &) = delete;
+  OwnershipHelper &operator=(const OwnershipHelper &) = delete;
+  OwnershipHelper(OwnershipHelper &&) noexcept = default;
+  OwnershipHelper &operator=(OwnershipHelper &&) noexcept = default;
+
+  // Operations
+  std::shared_ptr<T> getStrong() const;
+  bool becomeOwner();
+  bool becomeBorrower();
+  void hold(std::shared_ptr<T> strong);
+  void hold(std::weak_ptr<T> weak);
+
+  // Operators
+  bool operator==(const OwnershipHelper &other) const;
+  bool operator<(const OwnershipHelper &other) const;
+  bool operator!=(const OwnershipHelper &other) const;
+  bool operator>(const OwnershipHelper &other) const;
+  bool operator<=(const OwnershipHelper &other) const;
+  bool operator>=(const OwnershipHelper &other) const;
+
+private:
+  std::variant<std::shared_ptr<T>, std::weak_ptr<T>> d_value;
+};
+
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const OwnershipHelper<T> &fn);
+
+// Definitions
+
+template <typename T>
+OwnershipHelper<T>::OwnershipHelper(std::shared_ptr<T> strong)
+    : d_value(strong) {}
+
+template <typename T>
+OwnershipHelper<T>::OwnershipHelper(std::weak_ptr<T> weak) : d_value(weak) {}
+
+template <typename T> std::shared_ptr<T> OwnershipHelper<T>::getStrong() const {
+  if (std::holds_alternative<std::shared_ptr<T>>(d_value)) {
+    return std::get<std::shared_ptr<T>>(d_value);
+  }
+
+  auto weak = std::get<std::weak_ptr<T>>(d_value);
+  return weak.lock();
+}
+
+template <typename T> bool OwnershipHelper<T>::becomeOwner() {
+  if (std::holds_alternative<std::shared_ptr<T>>(d_value)) {
+    return true;
+  }
+
+  auto weak = std::get<std::weak_ptr<T>>(d_value);
+  if (auto strong = weak.lock()) {
+    d_value = strong;
+    return true;
+  }
+  return false;
+}
+
+template <typename T> bool OwnershipHelper<T>::becomeBorrower() {
+  if (std::holds_alternative<std::shared_ptr<T>>(d_value)) {
+    d_value = std::weak_ptr<T>(std::get<std::shared_ptr<T>>(d_value));
+    return true;
+  }
+
+  return true;
+}
+
+template <typename T> void OwnershipHelper<T>::hold(std::shared_ptr<T> strong) {
+  d_value = strong;
+}
+
+template <typename T> void OwnershipHelper<T>::hold(std::weak_ptr<T> weak) {
+  d_value = weak;
+}
+
+template <typename T>
+bool OwnershipHelper<T>::operator==(const OwnershipHelper &other) const {
+  // N.B. This will result in 2 expired weak_ptrs being equal even if they
+  // originally pointed to different things.
+  return getStrong() == other.getStrong();
+}
+
+template <typename T>
+bool OwnershipHelper<T>::operator<(const OwnershipHelper &other) const {
+  return getStrong() < other.getStrong();
+}
+
+template <typename T>
+bool OwnershipHelper<T>::operator!=(const OwnershipHelper<T> &other) const {
+  return !(*this == other);
+}
+
+template <typename T>
+bool OwnershipHelper<T>::operator>(const OwnershipHelper<T> &other) const {
+  return other < *this;
+}
+
+template <typename T>
+bool OwnershipHelper<T>::operator<=(const OwnershipHelper<T> &other) const {
+  return !(*this > other);
+}
+
+template <typename T>
+bool OwnershipHelper<T>::operator>=(const OwnershipHelper<T> &other) const {
+  return !(*this < other);
+}
+
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const OwnershipHelper<T> &ownHlpr) {
+  // Component should be invisible to client
+  os << *ownHlpr.getStrong();
+  return os;
+}
+
+} // namespace treewalk
+} // namespace plox
+
+#endif

--- a/tree-walk/src/parser.cpp
+++ b/tree-walk/src/parser.cpp
@@ -18,12 +18,12 @@
 // classStmt      →  "class" IDENTIFIER ("<" IDENTIFIER)? "{" function* "}" ;
 // exprStmt       → expression ";" ;
 // funcStmt       → "fun" function ;
-// forStmt        → "for" "(" (varStmt | exprStmt | ";") expression? ";" expression? ")" statement ";" ;
-// ifStmt         → "if" "(" expression ")" statement ("else" statement)? ";" ;
+// forStmt        → "for" "(" (varStmt | exprStmt | ";") expression? ";" expression? ")" statement ;
+// ifStmt         → "if" "(" expression ")" statement ("else" statement)? ;
 // printStmt      → "print" expression ";" ;
 // returnStmt     → "return" expression? ";" ;
 // varStmt        → "var" IDENTIFIER ( "=" expression )? ";" ;
-// whileStmt      → "while" "(" expression ")" statement ";" ;
+// whileStmt      → "while" "(" expression ")" statement ;
 
 // expression     → assignment ;
 // assignment     → ( call "." ) ? IDENTIFIER "=" assignment | equality ;
@@ -375,13 +375,7 @@ std::unique_ptr<stmt::Stmt> forStatement(TokenStream &tokStream) {
 
   // Read body
   std::get<stmt::For>(*forStmt).body = statement(tokStream);
-
-  if (TokenType::SEMICOLON == tokStream.peek().type) {
-    tokStream.next();
-    return forStmt;
-  }
-  throw ParseException("No ending semi colon found for 'for' stmt!",
-                       tokStream.peek().line);
+  return forStmt;
 }
 
 std::unique_ptr<stmt::Stmt> funStatement(TokenStream &tokStream) {
@@ -471,12 +465,7 @@ std::unique_ptr<stmt::Stmt> ifStatement(TokenStream &tokStream) {
     std::get<stmt::If>(*ifStmt).elseBranch = statement(tokStream);
   }
 
-  if (TokenType::SEMICOLON == tokStream.peek().type) {
-    tokStream.next();
-    return ifStmt;
-  }
-  throw ParseException("No ending semi colon found for if stmt!",
-                       tokStream.peek().line);
+  return ifStmt;
 }
 
 std::unique_ptr<stmt::Stmt> printStatement(TokenStream &tokStream) {
@@ -559,13 +548,7 @@ std::unique_ptr<stmt::Stmt> whileStatement(TokenStream &tokStream) {
 
   // Read body
   std::get<stmt::While>(*whileStmt).body = statement(tokStream);
-
-  if (TokenType::SEMICOLON == tokStream.peek().type) {
-    tokStream.next();
-    return whileStmt;
-  }
-  throw ParseException("No ending semi colon found for while stmt!",
-                       tokStream.peek().line);
+  return whileStmt;
 }
 
 std::unique_ptr<stmt::Stmt> statement(TokenStream &tokStream) {

--- a/tree-walk/src/scanner.cpp
+++ b/tree-walk/src/scanner.cpp
@@ -171,7 +171,6 @@ std::vector<Token> scanTokens(const std::string_view code,
         while (code.at(pos) != '\n') {
           pos++;
         }
-        pos++;
         line++;
       } else {
         tokens.emplace_back(TokenType::SLASH, std::string_view(&c, 1), line);

--- a/tree-walk/src/scanner.cpp
+++ b/tree-walk/src/scanner.cpp
@@ -129,8 +129,6 @@ std::vector<Token> scanTokens(const std::string_view code,
       tokens.emplace_back(TokenType::PLUS, std::string_view(&c, 1), line);
     } else if (c == ';') {
       tokens.emplace_back(TokenType::SEMICOLON, std::string_view(&c, 1), line);
-    } else if (c == '/') {
-      tokens.emplace_back(TokenType::SLASH, std::string_view(&c, 1), line);
     } else if (c == '*') {
       tokens.emplace_back(TokenType::STAR, std::string_view(&c, 1), line);
     }
@@ -166,6 +164,17 @@ std::vector<Token> scanTokens(const std::string_view code,
         pos++; // 2 char token
       } else {
         tokens.emplace_back(TokenType::GREATER, std::string_view(&c, 1), line);
+      }
+    } else if (c == '/') {
+      if (nextCharEquals(code, pos, '/')) {
+        // comment - skip till next line
+        while (code.at(pos) != '\n') {
+          pos++;
+        }
+        pos++;
+        line++;
+      } else {
+        tokens.emplace_back(TokenType::SLASH, std::string_view(&c, 1), line);
       }
     }
     // literals

--- a/tree-walk/src/scanner.cpp
+++ b/tree-walk/src/scanner.cpp
@@ -168,7 +168,7 @@ std::vector<Token> scanTokens(const std::string_view code,
     } else if (c == '/') {
       if (nextCharEquals(code, pos, '/')) {
         // comment - skip till next line
-        while (code.at(pos) != '\n') {
+        while (pos < code.size() && code.at(pos) != '\n') {
           pos++;
         }
         line++;

--- a/tree-walk/src/value.h
+++ b/tree-walk/src/value.h
@@ -14,10 +14,11 @@ using ClsInstShrdPtr = std::shared_ptr<ClassInstance>;
 struct ClassDefinition;
 using ClsDefShrdPtr = std::shared_ptr<ClassDefinition>;
 struct FunctionDescription;
-using FnDescShrdPtr = std::shared_ptr<FunctionDescription>;
+template <typename T> struct OwnershipHelper;
+using FnDescOwnrHlpr = std::shared_ptr<OwnershipHelper<FunctionDescription>>;
 
 using Value = std::variant<std::monostate, std::string, bool, double,
-                           FnDescShrdPtr, ClsDefShrdPtr, ClsInstShrdPtr>;
+                           FnDescOwnrHlpr, ClsDefShrdPtr, ClsInstShrdPtr>;
 
 } // namespace treewalk
 } // namespace plox

--- a/tree-walk/src/value_printer.h
+++ b/tree-walk/src/value_printer.h
@@ -14,13 +14,6 @@
 namespace plox {
 namespace treewalk {
 
-using ClsInstShrdPtr = std::shared_ptr<ClassInstance>;
-using ClsDefShrdPtr = std::shared_ptr<ClassDefinition>;
-using FnDescShrdPtr = std::shared_ptr<FunctionDescription>;
-
-using Value = std::variant<std::monostate, std::string, bool, double,
-                           FnDescShrdPtr, ClsDefShrdPtr, ClsInstShrdPtr>;
-
 // Concepts to control which template method should be chosen
 template <typename T>
 concept SharedPtr =

--- a/tree-walk/systemtest/conftest.py
+++ b/tree-walk/systemtest/conftest.py
@@ -6,7 +6,7 @@ import subprocess
 
 @pytest.fixture
 def lox_runner():
-    BIN = Path(__file__).resolve().parent / "../../build/tree-walk/src/tree-walk"
+    BIN = Path(__file__).resolve().parent / "../../build-asan/tree-walk/src/tree-walk"
 
     def run(code):
         result = subprocess.run([BIN, "-c", code], capture_output=True, text=True)

--- a/tree-walk/systemtest/test_comments.py
+++ b/tree-walk/systemtest/test_comments.py
@@ -1,0 +1,15 @@
+def test_comments(lox_runner):
+    # GIVEN
+    code = """
+    var a = 15; // This is a variable a
+    var b = 2;
+    // The above variable is var b
+    print a + b;
+    """
+
+    # WHEN
+    stdout, stderr = lox_runner(code)
+
+    # THEN
+    assert stdout.strip().splitlines() == ["17"]
+    assert stderr == ""

--- a/tree-walk/systemtest/test_comments.py
+++ b/tree-walk/systemtest/test_comments.py
@@ -1,10 +1,10 @@
 def test_comments(lox_runner):
     # GIVEN
     code = """
-    var a = 15; // This is a variable a
-    var b = 2;
-    // The above variable is var b
-    print a + b;
+var a = 15; // This is a variable a
+var b = 2;
+// The above variable is var b
+print a + b;
     """
 
     # WHEN

--- a/tree-walk/systemtest/test_for.py
+++ b/tree-walk/systemtest/test_for.py
@@ -3,7 +3,6 @@ def test_for(lox_runner):
     code = """
     for (var i = 0; i<5; i=i+1)
         print(i);
-    ;
     """
 
     # WHEN

--- a/tree-walk/systemtest/test_fun.py
+++ b/tree-walk/systemtest/test_fun.py
@@ -120,6 +120,33 @@ def test_fun_closure(lox_runner):
     assert stderr == ""
 
 
+def test_fun_closure_recursion(lox_runner):
+    # GIVEN
+    code = """
+    fun nTimesX(x) {
+        var count = 0;
+        fun closure(n) {
+            if (n == 0) {
+                return count;
+            }
+            count = count + x;
+            n = n - 1;
+            return closure(n);
+        }
+        return closure;
+    }
+    var a = nTimesX(3)(5);
+    print a;
+    """
+
+    # WHEN
+    stdout, stderr = lox_runner(code)
+
+    # THEN
+    assert stdout.strip().splitlines() == ["15"]
+    assert stderr == ""
+
+
 def test_function_as_arg(lox_runner):
     # GIVEN
     code = """

--- a/tree-walk/systemtest/test_if.py
+++ b/tree-walk/systemtest/test_if.py
@@ -5,7 +5,6 @@ def test_if(lox_runner):
         print(15);
     else 
         print(0);
-    ;
     """
 
     # WHEN
@@ -23,7 +22,6 @@ def test_else(lox_runner):
         print(15);
     else 
         print(0);
-    ;
     """
 
     # WHEN

--- a/tree-walk/systemtest/test_keywords.py
+++ b/tree-walk/systemtest/test_keywords.py
@@ -1,0 +1,13 @@
+def test_nil(lox_runner):
+    # GIVEN
+    code = """
+    var a = nil;
+    print a;
+    """
+
+    # WHEN
+    stdout, stderr = lox_runner(code)
+
+    # THEN
+    assert stdout.strip().splitlines() == ["NULL"]
+    assert stderr == ""

--- a/tree-walk/systemtest/test_operators.py
+++ b/tree-walk/systemtest/test_operators.py
@@ -1,0 +1,13 @@
+def test_operators(lox_runner):
+    # GIVEN
+    code = """
+    print "one " + 1;
+    print "two " + "two";
+    """
+
+    # WHEN
+    stdout, stderr = lox_runner(code)
+
+    # THEN
+    assert stdout.strip().splitlines() == ["one 1.000000", "two two"]
+    assert stderr == ""

--- a/tree-walk/systemtest/test_while.py
+++ b/tree-walk/systemtest/test_while.py
@@ -4,7 +4,6 @@ def test_while(lox_runner):
     var a = 15;
     while (a < 42)
         a = a * 2;
-    ;
     print(a);
     """
 

--- a/tree-walk/tests/environment.t.cpp
+++ b/tree-walk/tests/environment.t.cpp
@@ -10,68 +10,60 @@ namespace test {
 TEST(Environment, DefineAndGet) {
   // GIVEN
   auto envPtr = Environment::create();
-  Value initial = 42.0;
 
   // WHEN
-  envPtr->define("x", initial);
+  envPtr->define("x", 42.0);
 
   // THEN
-  EXPECT_EQ(envPtr->get("x"), initial);
+  EXPECT_EQ(envPtr->get("x"), Value{42.0});
 }
 
 TEST(Environment, AssignAndGet) {
   // GIVEN
   auto envPtr = Environment::create();
-  Value initial = 42.0;
-  Value updated = "hi";
 
   // WHEN
-  envPtr->define("x", initial);
-  envPtr->assign("x", updated);
+  envPtr->define("x", 42.0);
+  envPtr->assign("x", "hi");
 
   // THEN
-  EXPECT_EQ(envPtr->get("x"), updated);
+  EXPECT_EQ(envPtr->get("x"), Value{"hi"});
 }
 
 TEST(Environment, UpsertAndGet) {
   // GIVEN
   auto envPtr = Environment::create();
-  Value initial = 42.0;
-  Value updated = "hi";
 
   // WHEN
-  envPtr->upsertInScope("x", initial);
-  envPtr->upsertInScope("x", updated);
+  envPtr->upsertInScope("x", 42.0);
+  envPtr->upsertInScope("x", "hi");
 
   // THEN
-  EXPECT_EQ(envPtr->get("x"), updated);
+  EXPECT_EQ(envPtr->get("x"), Value{"hi"});
 }
 
 TEST(Environment, GetFromParentEnv) {
   // GIVEN
   auto parentPtr = Environment::create();
-  Value v = 99.0;
-  parentPtr->define("x", v);
+  parentPtr->define("x", 99.0);
   auto childPtr = Environment::create(parentPtr);
 
   // THEN
-  EXPECT_EQ(childPtr->get("x"), v);
+  EXPECT_EQ(childPtr->get("x"), Value{99.0});
 }
 
 TEST(Environment, AssignInParentEnv) {
   // GIVEN
   auto parentPtr = Environment::create();
-  Value initial = 50.0;
-  Value updated = true;
-  parentPtr->define("x", initial);
+  parentPtr->define("x", 50.0);
   auto childPtr = Environment::create(parentPtr);
 
   // WHEN
-  childPtr->assign("x", updated);
+  childPtr->assign("x", true);
 
   // THEN
-  EXPECT_EQ(childPtr->get("x"), updated);
-  EXPECT_EQ(parentPtr->get("x"), updated);
+  EXPECT_EQ(childPtr->get("x"), Value{true});
+  EXPECT_EQ(parentPtr->get("x"), Value{true});
 }
 
 TEST(Environment, GetUndefinedThrows) {

--- a/tree-walk/tests/interpreter.t.cpp
+++ b/tree-walk/tests/interpreter.t.cpp
@@ -40,7 +40,7 @@ TEST(Interpreter, smoke) {
   interpret(statements, env, errs);
 
   // Then
-  auto val = env->get("myVar");
+  auto &val = env->get("myVar");
   ASSERT_EQ(56.0, std::get<double>(val));
   ASSERT_EQ(0, errs.size());
 }
@@ -90,7 +90,7 @@ TEST(Interpreter, UseVar) {
   interpret(statements, env, errs);
 
   // Then
-  auto b = env->get("b");
+  auto &b = env->get("b");
   ASSERT_EQ(6, std::get<double>(b));
   ASSERT_EQ(0, errs.size());
 }
@@ -118,7 +118,7 @@ TEST(Interpreter, ReassignVar) {
   interpret(statements, env, errs);
 
   // Then
-  auto a = env->get("a");
+  auto &a = env->get("a");
   ASSERT_EQ(6, std::get<double>(a));
   ASSERT_EQ(0, errs.size());
 }

--- a/tree-walk/tests/scanner.t.cpp
+++ b/tree-walk/tests/scanner.t.cpp
@@ -84,6 +84,22 @@ TEST(Scanner, Print) {
   ASSERT_EQ(0, errors.size());
 }
 
+TEST(Scanner, Comments) {
+  // Given
+  std::vector<SyntaxException> errors;
+  std::string code = "print 1; //ayy";
+  std::vector<Token> expected{
+      Token{TokenType::PRINT, "print", 1}, Token{TokenType::NUMBER, "1", 1},
+      Token{TokenType::SEMICOLON, ";", 1}, Token{TokenType::EOF_, "", 2}};
+
+  // When
+  auto vec = scanTokens(code, errors);
+
+  // Then
+  ASSERT_EQ(expected, vec);
+  ASSERT_EQ(0, errors.size());
+}
+
 } // namespace test
 } // namespace treewalk
 } // namespace plox


### PR DESCRIPTION
Had some shared_ptr loops that were keeping memory around. 

Replacing that with an ownership concept. The owner(s) have a shared_ptr and borrowers have a weak_ptr. Note, there can be multiple owners (or multiple stakeholders who need an object to stay alive). An example of that is an object declared in an env and then being passed into a class (which is by reference). Both the environment where that object was declared and the class now have a stake in that object staying alive.